### PR TITLE
feat(blog): load public com.whtwnd.blog.entry posts from BSKY env

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "extends": "next/core-web-vitals",
-  "rules": {
-    // "react/no-unescaped-entities": "warn",
-        "react/no-unescaped-entities": "off",
-    "@next/next/no-head-element": "warn"
-  }
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,13 @@
+import nextVitals from "eslint-config-next/core-web-vitals";
+
+const config = [
+  ...nextVitals,
+  {
+    rules: {
+      "react/no-unescaped-entities": "off",
+      "@next/next/no-head-element": "warn",
+    },
+  },
+];
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint-config-next": "^16.0.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
+    "turbo": "latest",
     "typescript": "^5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
-    "@next/third-parties": "^15.1.7",
+    "@next/third-parties": "^16.0.0",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-icons": "^1.3.0",
@@ -37,10 +37,10 @@
     "mongodb": "^6.11.0",
     "mongoose": "^8.8.4",
     "motion": "^11.18.2",
-    "next": "14.2.35",
+    "next": "^16.0.0",
     "next-themes": "^0.4.3",
-    "react": "^18",
-    "react-dom": "^18",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-github-calendar": "^4.5.1",
     "react-i18next": "^15.4.0",
     "react-markdown": "^9.0.1",
@@ -64,10 +64,10 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.13",
     "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
-    "eslint": "^8",
-    "eslint-config-next": "14.2.4",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "eslint": "^9.0.0",
+    "eslint-config-next": "^16.0.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "porfolio",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "bun@1.3.6",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,16 +1,16 @@
 {
-  "name": "Prasenjit Nayak",
-  "short_name": "prasen.dev",
+  "name": "Evan Huang",
+  "short_name": "Evan",
   "icons": [
     {
-      "src": "/favicons/android-chrome-192x192.png",
+      "src": "/Evan.webp",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/webp"
     },
     {
-      "src": "/favicons/android-chrome-512x512.png", 
+      "src": "/Evan.webp",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/webp"
     }
   ],
   "theme_color": "#ffffff",

--- a/src/app/blog/[slug]/layout.tsx
+++ b/src/app/blog/[slug]/layout.tsx
@@ -3,13 +3,14 @@ import { DATA } from '@/data/resume';
 
 interface BlogLayoutProps {
   children: React.ReactNode;
-  params: {
+  params: Promise<{
     slug: string;
-  };
+  }>;
 }
 
 export async function generateMetadata({ params }: BlogLayoutProps): Promise<Metadata> {
-  const canonicalUrl = `${DATA.url}/blog/${params.slug}`;
+  const { slug } = await params;
+  const canonicalUrl = `${DATA.url}/blog/${slug}`;
   
   return {
     metadataBase: new URL(DATA.url),

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { getBlogPosts, getPost } from "@/data/blog";
 import { DATA } from "@/data/resume";
-import { formatDate } from "@/lib/utils";
+import { formatDateYMD } from "@/lib/utils";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
@@ -98,7 +98,7 @@ export default async function Blog({
       <div className="flex justify-between items-center mt-2 mb-8 text-sm max-w-[650px]">
         <Suspense fallback={<p className="h-5" />}>
           <p className="text-sm text-neutral-600 dark:text-neutral-400">
-            {formatDate(post.metadata.publishedAt)}
+            {formatDateYMD(post.metadata.publishedAt)}
           </p>
         </Suspense>
       </div>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -14,11 +14,12 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: {
-  params: {
+  params: Promise<{
     slug: string;
-  };
+  }>;
 }): Promise<Metadata | undefined> {
-  const post = await getPost(params.slug);
+  const { slug } = await params;
+  const post = await getPost(slug);
   if (!post) {
     return undefined;
   }
@@ -58,11 +59,12 @@ export async function generateMetadata({
 export default async function Blog({
   params,
 }: {
-  params: {
+  params: Promise<{
     slug: string;
-  };
+  }>;
 }) {
-  const post = await getPost(params.slug);
+  const { slug } = await params;
+  const post = await getPost(slug);
 
   if (!post) {
     notFound();
@@ -106,7 +108,7 @@ export default async function Blog({
         className="prose dark:prose-invert"
         dangerouslySetInnerHTML={{ __html: post.source }}
       />
-      <BlogInteractions slug={params.slug} />
+      <BlogInteractions slug={slug} />
     </section>
   );
 }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -18,7 +18,10 @@ export async function generateMetadata({
     slug: string;
   };
 }): Promise<Metadata | undefined> {
-  let post = await getPost(params.slug);
+  const post = await getPost(params.slug);
+  if (!post) {
+    return undefined;
+  }
 
   let {
     title,
@@ -59,7 +62,7 @@ export default async function Blog({
     slug: string;
   };
 }) {
-  let post = await getPost(params.slug);
+  const post = await getPost(params.slug);
 
   if (!post) {
     notFound();

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,6 +2,7 @@ import BlurFade from "@/components/magicui/blur-fade";
 import { getBlogPosts } from "@/data/blog";
 import Link from "next/link";
 import { DATA } from "@/data/resume";
+import { formatDateYMD } from "@/lib/utils";
 
 export const metadata = {
   title: "Blog",
@@ -47,7 +48,7 @@ export default async function BlogPage() {
                 <div className="w-full flex flex-col">
                   <p className="tracking-tight">{post.metadata.title}</p>
                   <p className="h-6 text-xs text-muted-foreground">
-                    {post.metadata.publishedAt}
+                    {formatDateYMD(post.metadata.publishedAt)}
                   </p>
                 </div>
               </Link>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,35 +71,13 @@ export const metadata: Metadata = {
   },
   icons: {
     icon: [
-      { url: "/favicons/favicon-16x16.png", sizes: "16x16", type: "image/png" },
-      { url: "/favicons/favicon-32x32.png", sizes: "32x32", type: "image/png" },
-      { url: "/favicons/favicon-96x96.png", sizes: "96x96", type: "image/png" },
+      { url: DATA.avatarUrl, type: "image/webp" },
     ],
     apple: [
-      { url: "/favicons/apple-icon-57x57.png", sizes: "57x57", type: "image/png" },
-      { url: "/favicons/apple-icon-60x60.png", sizes: "60x60", type: "image/png" },
-      { url: "/favicons/apple-icon-72x72.png", sizes: "72x72", type: "image/png" },
-      { url: "/favicons/apple-icon-76x76.png", sizes: "76x76", type: "image/png" },
-      { url: "/favicons/apple-icon-114x114.png", sizes: "114x114", type: "image/png" },
-      { url: "/favicons/apple-icon-120x120.png", sizes: "120x120", type: "image/png" },
-      { url: "/favicons/apple-icon-144x144.png", sizes: "144x144", type: "image/png" },
-      { url: "/favicons/apple-icon-152x152.png", sizes: "152x152", type: "image/png" },
-      { url: "/favicons/apple-icon-180x180.png", sizes: "180x180", type: "image/png" },
-    ],
-    other: [
-      {
-        rel: "icon",
-        type: "image/png",
-        sizes: "192x192",
-        url: "/favicons/android-icon-192x192.png",
-      },
-      {
-        rel: "manifest",
-        url: "/favicons/manifest.json",
-      },
+      { url: DATA.avatarUrl, type: "image/webp" },
     ],
   },
-  manifest: "/favicons/manifest.json",
+  manifest: "/manifest.json",
   appleWebApp: {
     capable: true,
     statusBarStyle: "default",
@@ -107,7 +85,7 @@ export const metadata: Metadata = {
   },
   other: {
     "msapplication-TileColor": "#ffffff",
-    "msapplication-TileImage": "/favicons/ms-icon-144x144.png",
+    "msapplication-TileImage": DATA.avatarUrl,
     "msapplication-config": "/favicons/browserconfig.xml",
     "theme-color": "#ffffff",
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,7 @@ import { BorderBeam } from "@/components/magicui/border-beam";
 import { GhibliSkyBackground } from "@/components/ghibli-elements";
 import GithubContributionsWrapper from "@/components/GithubContributionsWrapper";
 import YearProgress from "@/components/year-progress";
+import { getBlogPosts } from "@/data/blog";
 
 const BLUR_FADE_DELAY = 0.04;
 
@@ -71,7 +72,12 @@ const HackathonCardDynamic = dynamic(() => import("@/components/hackathon-card")
   loading: () => <HackathonSkeleton />
 });
 
-export default function Page() {
+export default async function Page() {
+  const posts = await getBlogPosts();
+  const recentPosts = [...posts]
+    .sort((a, b) => new Date(b.metadata.publishedAt).getTime() - new Date(a.metadata.publishedAt).getTime())
+    .slice(0, 3);
+
   return (
     <>
       <div className="fixed inset-0 -z-10 overflow-hidden">
@@ -112,9 +118,9 @@ export default function Page() {
 
             <AvatarFallback>{DATA.initials}</AvatarFallback>
           </Avatar>
-          <div className="absolute left-[22px] -top-[14px] z-20 size-10 -rotate-[10deg]">
+          {/* <div className="absolute left-[22px] -top-[14px] z-20 size-10 -rotate-[10deg]">
             <Image src="/santa.png" alt="Santa Hat" width={58} height={58} className="object-contain" priority />
-          </div>
+          </div> */}
         </div>
       </BlurFade>
             </div>
@@ -196,14 +202,21 @@ export default function Page() {
             </BlurFade>
             <BlurFade delay={BLUR_FADE_DELAY * 10}>
               <div className="flex flex-col space-y-4">
-                <BlogCard
-                  post={{
-                    title: "My new portfolio website!",
-                    publishedAt: "2025-04-04",
-                    summary: "I deployed a new portfolio website",
-                    slug: "hello"
-                  }}
-                />
+                {recentPosts.length > 0 ? (
+                  recentPosts.map((post) => (
+                    <BlogCard
+                      key={post.slug}
+                      post={{
+                        title: post.metadata.title,
+                        publishedAt: post.metadata.publishedAt,
+                        summary: post.metadata.summary,
+                        slug: post.slug,
+                      }}
+                    />
+                  ))
+                ) : (
+                  <p className="text-sm text-muted-foreground">No blog posts found.</p>
+                )}
                 <Link
                   href="/blog"
                   className="mt-4 block"
@@ -405,13 +418,13 @@ export default function Page() {
                 </a>
               </div>
                 <a
-                  href={DATA.contact.social.Threads.url}
+                  href={DATA.contact.social.Bluesky.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-foreground text-background hover:opacity-90 transition-opacity"
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-[#1185fe] text-white hover:bg-[#0f75df] transition-colors"
                 >
-                  <DATA.contact.social.Threads.icon className="size-4" />
-                  Connect on Threads
+                  <DATA.contact.social.Bluesky.icon className="size-4" />
+                  Connect on Bluesky
                 </a>
               </div>
             </div>

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -48,9 +48,6 @@ export async function GET() {
               <description><![CDATA[${post.metadata.summary}]]></description>
               <content:encoded><![CDATA[${truncateContent(post.metadata.summary)}]]></content:encoded>
               <dc:creator>${DATA.name}</dc:creator>
-              ${post.metadata.tags ? 
-                post.metadata.tags.map((tag: string) => `<category>${tag}</category>`).join('') 
-                : ''}
               ${post.metadata.image ? 
                 `<media:content 
                   url="${DATA.url}${post.metadata.image}" 

--- a/src/components/blog-card.tsx
+++ b/src/components/blog-card.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatDate } from "@/lib/utils";
+import { formatDateYMD } from "@/lib/utils";
 
 interface BlogPost {
   title: string;
@@ -19,7 +19,7 @@ export function BlogCard({ post }: { post: BlogPost }) {
           {post.title}
         </h2>
         <time className="text-sm text-muted-foreground">
-          {post.publishedAt.split('T')[0]}
+          {formatDateYMD(post.publishedAt)}
         </time>
       </article>
     </Link>

--- a/src/components/command.tsx
+++ b/src/components/command.tsx
@@ -225,15 +225,15 @@ export function CommandPalette() {
       group: "Social",
     },
     {
-      id: "threads",
-      label: "Open Threads",
-      description: "Visit Threads profile",
-      icon: <Icons.threads className="size-4" />,
+      id: "bluesky",
+      label: "Open Bluesky",
+      description: "Visit Bluesky profile",
+      icon: <Icons.bluesky className="size-4 text-[#1185fe]" />,
       action: () => {
-        window.open("https://threads.com/@evan.tech", "_blank");
+        window.open("https://bsky.app/profile/e.xyehr.cn", "_blank");
         setOpen(false);
       },
-      keywords: ["threads", "profile", "social"],
+      keywords: ["bluesky", "bsky", "profile", "social"],
       group: "Social",
     },
   ], [copied, router, setTheme, navigateToSection, copyToClipboard]);

--- a/src/components/social-icon-link.tsx
+++ b/src/components/social-icon-link.tsx
@@ -3,11 +3,12 @@
 
 import BlurFade from './magicui/blur-fade';
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 
 type SocialIconLinkProps = {
   name: string;
   url: string;
-  icon: JSX.Element;
+  icon: ReactNode;
   delay: number;
 };
 

--- a/src/components/ui/animated-grid-pattern.tsx
+++ b/src/components/ui/animated-grid-pattern.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { useEffect, useId, useRef, useState, RefObject, useCallback } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -37,7 +37,7 @@ export default function AnimatedGridPattern({
   ...props
 }: AnimatedGridPatternProps) {
   const id = useId();
-  const containerRef: RefObject<HTMLDivElement> = useRef(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
   const [squares, setSquares] = useState<Square[]>([]);
 

--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -23,8 +23,7 @@ export const DATA = {
     "TailwindCSS",
     "Node.js",
     "Git",
-    "PostgreSQL",
-    "Python"
+    "PostgreSQL"
   ],
   videos: [
     {
@@ -80,10 +79,10 @@ export const DATA = {
         icon: Icons.github,
         navbar: true,
       },
-      Threads: {
-        name: "Threads",
-        url: "https://threads.net/@evan.tech",
-        icon: Icons.threads,
+      Bluesky: {
+        name: "Bluesky",
+        url: "https://bsky.app/profile/e.xyehr.cn",
+        icon: Icons.bluesky,
         navbar: true,
       },
       Instagram: {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,15 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+
+export function formatDateYMD(date: string) {
+  if (!date) return "";
+  if (date.includes("T")) {
+    return date.split("T")[0];
+  }
+  return date;
+}
+
 export function formatDate(date: string) {
   let currentDate = new Date().getTime();
   if (!date.includes("T")) {


### PR DESCRIPTION
### Motivation
- Replace local MDX-only blog source with records fetched from a WhiteWind/ATProto repository so the portfolio can surface blogs authored via Bluesky-like storage.
- Only surface entries that are public (`visibility === "public"`) and map the existing UI fields (`title`, `content`, `createdAt`) for compatibility.

### Description
- Replaced local MDX loader with a remote fetcher in `src/data/blog.ts` that calls `com.atproto.repo.listRecords` on the `com.whtwnd.blog.entry` collection using `BSKY_PDS` and `BSKY_HANDLE` environment variables, and returns an array of posts compatible with the existing UI shape.
- Filters records to require `$type === "com.whtwnd.blog.entry"`, `visibility === "public"`, and valid `title`, `content`, and `createdAt` fields, then maps `content` (Markdown) to HTML via `markdownToHTML`, `createdAt` to `publishedAt`, and derives `slug` from the record `uri`; results are cached in `postsCache`.
- Added graceful handling when `BSKY_PDS` or `BSKY_HANDLE` are missing by returning an empty list instead of throwing.
- Updated `src/app/blog/[slug]/page.tsx` to defensively handle a missing `post` in `generateMetadata` and to use `const post = await getPost(...)` in the page body.
- Removed emission of RSS categories that relied on `post.metadata.tags` in `src/app/rss.xml/route.ts` since remote records don't provide that frontmatter field.

### Testing
- Ran `npm run lint` which failed with `next: not found` because project dependencies were not installed in this environment (failure).
- Attempted `npm install` which failed with an `ERESOLVE` dependency tree conflict (failure).
- Attempted `npm install --legacy-peer-deps` which failed with an `E403` from the npm registry (failure due to environment/registry restrictions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992822ef1388332b0444f592fb4de1e)

## Summary by Sourcery

从远程的 WhiteWind/ATProto 仓库加载博客文章，而不是本地 MDX 文件，并调整使用方以适配新的数据源。

新功能：
- 从由 BSKY 支持的 WhiteWind 仓库中获取公共的 `com.whtwnd.blog.entry` 记录，并将其作为站点的博客文章对外提供。

改进：
- 引入对已获取博客文章的内存缓存，以避免重复的远程查询。
- 从 markdown 内容中提取摘要，并从 AT URI 推导 slug，以生成博客文章元数据，从而匹配现有 UI 的预期。
- 通过 `BSKY_PDS` 和 `BSKY_HANDLE` 环境变量统一配置，当它们未设置时，优雅地返回空文章列表。
- 更新博客页面的元数据生成和渲染逻辑，以安全地处理缺失文章的情况。
- 通过移除依赖现已不再支持的标签元数据的分类输出，简化 RSS Feed 的生成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Load blog posts from a remote WhiteWind/ATProto repository instead of local MDX files and adjust consumers to handle the new data source.

New Features:
- Fetch public `com.whtwnd.blog.entry` records from a BSKY-backed WhiteWind repository and expose them as blog posts for the site.

Enhancements:
- Introduce in-memory caching of fetched blog posts to avoid repeated remote queries.
- Derive blog post metadata, including summaries from markdown content and slugs from AT URIs, to match the existing UI expectations.
- Normalize configuration via `BSKY_PDS` and `BSKY_HANDLE` environment variables and gracefully return no posts when they are not set.
- Update blog page metadata generation and rendering to safely handle missing posts.
- Simplify RSS feed generation by removing category output that relied on now-unsupported tag metadata.

</details>