### PR TITLE
fix

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -109,7 +109,7 @@
   }
 
   code {
-    @apply text-sm md:text-base !leading-loose;
+    @apply text-sm md:text-base;
   }
   
   pre > code {
@@ -130,39 +130,19 @@
     }
   }
   
-  code[data-line-numbers] {
-    counter-reset: line;
-  }
-  
   code[data-line-numbers] > [data-line]::before {
     counter-increment: line;
     content: counter(line);
     @apply inline-block w-4 mr-4 text-right text-gray-500;
   }
- 
-  code {
-    counter-reset: line;
+
+  code[data-line-numbers-max-digits="2"] > [data-line]::before {
+    width: 2rem;
   }
- 
-  code > [data-line]::before {
-  counter-increment: line;
-  content: counter(line);
- 
-  /* Other styling */
-  display: inline-block;
-  width: 1rem;
-  margin-right: 2rem;
-  text-align: right;
-  color: gray;
-}
- 
-code[data-line-numbers-max-digits="2"] > [data-line]::before {
-  width: 2rem;
-}
- 
-code[data-line-numbers-max-digits="3"] > [data-line]::before {
-  width: 3rem;
-}
+
+  code[data-line-numbers-max-digits="3"] > [data-line]::before {
+    width: 3rem;
+  }
 
 @keyframes border-pulse {
   0% {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -138,15 +138,6 @@ export default async function Page() {
           </BlurFade>
         </section>
         
-        <section id="views">
-          <BlurFade delay={BLUR_FADE_DELAY * 3}>
-            <h2 className="text-xl font-bold">Views</h2>
-          </BlurFade>
-          <BlurFade delay={BLUR_FADE_DELAY * 4}>
-            <img src="https://count.getloli.com/get/@Dev-Huang1.github.readme" alt="Views" />
-          </BlurFade>
-        </section>
-
         <section id="progress">
           <BlurFade delay={BLUR_FADE_DELAY * 3}>
             <h2 className="text-xl font-bold">Progress</h2>
@@ -175,16 +166,20 @@ export default async function Page() {
           </BlurFade>
         </section>
 
+        <section id="views">
+          <BlurFade delay={BLUR_FADE_DELAY * 3}>
+            <h2 className="text-xl font-bold">Views</h2>
+          </BlurFade>
+          <BlurFade delay={BLUR_FADE_DELAY * 4}>
+            <img src="https://count.getloli.com/get/@Dev-Huang1.github.readme" alt="Views" />
+          </BlurFade>
+        </section>
+
         <section id="skills">
           <div className="flex min-h-0 flex-col gap-y-3">
             <BlurFade delay={BLUR_FADE_DELAY * 9}>
               <h2 className="text-xl font-bold">Skills</h2>
             </BlurFade>
-            <div className="flex flex-wrap gap-1">
-              <BlurFade delay={BLUR_FADE_DELAY * 10}>
-                <img src="https://skills.syvixor.com/api/icons?perline=5&i=nextjs,react,typescript,javascript,tailwindcss,nodejs,postgresql,supabase,git,cloudflare" alt="Skills" />
-              </BlurFade>
-            </div>
             <div className="flex flex-wrap gap-1">
                 {DATA.skills.map((skill, id) => (
                 <BlurFade key={skill} delay={BLUR_FADE_DELAY * 10 + id * 0.05}>


### PR DESCRIPTION
### Motivation
- 修复在部分 blog 代码块中符号/高亮难以辨认的问题，避免行号伪元素样式与代码内容发生视觉冲突。 
- 简化首页 Skills 区块的展示，移除外部技能图以减少视觉干扰和外部请求。 
- 调整首页版块顺序，使 `Views` 区块位于联系人（`connect`）区块下方以改善信息流。 

### Description
- 修改 `src/app/globals.css`，移除对所有 `code` 元素生效的重复行号伪元素规则并去掉 `!leading-loose`，仅保留对带有行号数据属性的 `code[data-line-numbers]` 的行号样式以避免前缀覆盖代码符号。 
- 在 `src/app/globals.css` 中整理并保留了 `code[data-line-numbers-max-digits=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d07bf4bc748332bc24ddf6ff1a1958)

## Summary by Sourcery

改进博客代码块的可读性，并简化主页各版块的布局。

Bug 修复：
- 调整全局代码样式和行号伪元素，防止视觉冲突，并提升博客代码块中符号的清晰度。

增强功能：
- 优化行号样式，使其仅应用于带有行号属性的代码块，并根据最大数字位数调整宽度。
- 重新排列主页结构，使 Views 部分显示在 Connect/contact 部分下方、Skills 部分上方，并通过移除外部技能图片来简化 Skills 部分的内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve blog code block readability and simplify the home page sections layout.

Bug Fixes:
- Adjust global code styling and line-number pseudo-elements to prevent visual conflicts and improve symbol legibility in blog code blocks.

Enhancements:
- Refine line-number styling to only apply on code blocks with line-number attributes, with width adjustments based on maximum digit count.
- Reorder the home page so the Views section appears below the Connect/contact section and above Skills, and simplify the Skills section content by removing the external skills image.

</details>