### PR TITLE
fix

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ import { GoogleAnalytics } from '@next/third-parties/google'
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { CommandPalette } from "@/components/command";
 import { BackToTop } from "@/components/back-to-top";
+import { AtprotoOAuthBootstrap } from "@/components/atproto-oauth-bootstrap";
 import { GeistSans } from "geist/font/sans"
 
 /* const fontSans = FontSans({
@@ -123,6 +124,7 @@ export default function RootLayout({
             `}
           </Script>
           <JsonLd />
+          <AtprotoOAuthBootstrap />
           <ScrollProgress />
           <ThemeProvider
             attribute="class"

--- a/src/components/atproto-oauth-bootstrap.tsx
+++ b/src/components/atproto-oauth-bootstrap.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from 'react';
+import { restoreOAuthSession } from '@/lib/atreply-oauth';
+
+export function AtprotoOAuthBootstrap() {
+  useEffect(() => {
+    restoreOAuthSession().catch(console.error);
+  }, []);
+
+  return null;
+}

--- a/src/lib/atreply-oauth.ts
+++ b/src/lib/atreply-oauth.ts
@@ -3,6 +3,8 @@
 import { BrowserOAuthClient } from '@atproto/oauth-client-browser';
 import type { AtReplySession } from './atreply';
 
+const SESSION_STORAGE_KEY = 'atreply_oauth_session';
+
 function toSession(raw: any): AtReplySession | null {
   if (!raw) return null;
   return {
@@ -26,13 +28,27 @@ async function createOAuthClient() {
 export async function restoreOAuthSession() {
   try {
     const client = await createOAuthClient();
-    const hasOauthParams = window.location.search.includes('code=') || window.location.search.includes('iss=');
+    const hasOauthParams =
+      window.location.search.includes('code=') ||
+      window.location.search.includes('iss=') ||
+      window.location.hash.includes('code=') ||
+      window.location.hash.includes('iss=');
     if (hasOauthParams) {
       const result = await client.callback?.(window.location.href);
+      const session = toSession(result?.session ?? result);
+      if (session) {
+        window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+      }
       window.history.replaceState({}, document.title, window.location.pathname);
-      return toSession(result?.session ?? result);
+      return session;
     }
-    return toSession(await client.restore?.());
+    const restored = toSession(await client.restore?.());
+    if (restored) {
+      window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(restored));
+      return restored;
+    }
+    const localSession = window.localStorage.getItem(SESSION_STORAGE_KEY);
+    return localSession ? toSession(JSON.parse(localSession)) : null;
   } catch (error) {
     console.error(error);
     return null;


### PR DESCRIPTION
### Motivation
- OAuth 回调被配置为跳回到 `/blog`，但回调处理之前只在评论组件里触发，导致在 `/blog` 上未处理回调而看不到登录态。 
- 需要在应用根级别处理回调并保证登录会话能在页面间持久化，以便所有 blog 相关组件能检测到用户登录状态。

### Description
- 新增全局引导组件 `src/components/atproto-oauth-bootstrap.tsx`，在根布局挂载时调用 `restoreOAuthSession()` 以便在任意页面处理 OAuth 回调。 
- 在 `src/app/layout.tsx` 中引入并挂载 `AtprotoOAuthBootstrap`，确保回调在应用加载时就被处理。 
- 强化 `src/lib/atreply-oauth.ts` 中的 `restoreOAuthSession`：同时识别 query (`code`/`iss`) 和 hash (`#…`) 中的回调参数，回调成功后将会话写入 `localStorage`，并在 SDK `restore` 不可用时从 `localStorage` 回退恢复会话。 

### Testing
- 未运行或添加任何自动化测试。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f56eb68fd48332b79e4adb01ffbae1)

## Summary by Sourcery

在全局范围内处理 Atproto OAuth 会话恢复，确保登录状态可在博客各页面使用。

New Features:
- 在根布局中引入全局 Atproto OAuth 启动组件，以便在任何页面处理 OAuth 回调。

Bug Fixes:
- 确保返回到博客页面的 OAuth 回调能够正确建立并持久化用户会话，即使回调最初并非来自评论组件。

Enhancements:
- 扩展 OAuth 会话恢复逻辑，以处理同时存在于查询参数和哈希片段中的回调参数，并在 SDK 恢复不可用时，将会话持久化到 localStorage 作为回退机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle Atproto OAuth session restoration globally to ensure login state is available across blog pages.

New Features:
- Introduce a global Atproto OAuth bootstrap component mounted in the root layout to process OAuth callbacks on any page.

Bug Fixes:
- Ensure OAuth callbacks returning to blog pages correctly establish and persist the user session even when the callback originates outside the comments component.

Enhancements:
- Extend OAuth session restoration to handle callback parameters in both query and hash fragments and persist sessions in localStorage with a fallback when SDK-based restore is unavailable.

</details>