### PR TITLE
Fix race in atproto OAuth session restore by single-flight promise

### DIFF
--- a/src/lib/atreply-oauth.ts
+++ b/src/lib/atreply-oauth.ts
@@ -7,6 +7,8 @@ const SESSION_STORAGE_KEY = 'atreply_oauth_session';
 const RETURN_TO_STORAGE_KEY = 'atreply_oauth_return_to';
 export const ATREPLY_SESSION_EVENT = 'atreply:session-changed';
 
+let restorePromise: Promise<AtReplySession | null> | null = null;
+
 function toSession(raw: any): AtReplySession | null {
   if (!raw) return null;
   return {
@@ -37,37 +39,48 @@ async function createOAuthClient() {
   });
 }
 
-export async function restoreOAuthSession() {
-  try {
-    const client = await createOAuthClient();
-    const hasOauthParams =
-      window.location.search.includes('code=') ||
-      window.location.search.includes('iss=') ||
-      window.location.hash.includes('code=') ||
-      window.location.hash.includes('iss=');
-    if (hasOauthParams) {
-      const result = await client.callback?.(window.location.href);
-      const session = toSession(result?.session ?? result);
-      persistSession(session);
-      const returnTo = window.sessionStorage.getItem(RETURN_TO_STORAGE_KEY);
-      window.sessionStorage.removeItem(RETURN_TO_STORAGE_KEY);
-      window.history.replaceState({}, document.title, window.location.pathname);
-      if (returnTo && returnTo !== window.location.pathname) {
-        window.location.replace(returnTo);
+export function restoreOAuthSession() {
+  if (restorePromise) return restorePromise;
+
+  restorePromise = (async () => {
+    try {
+      const client = await createOAuthClient();
+      const hasOauthParams =
+        window.location.search.includes('code=') ||
+        window.location.search.includes('iss=') ||
+        window.location.hash.includes('code=') ||
+        window.location.hash.includes('iss=');
+
+      if (hasOauthParams) {
+        const result = await client.callback?.(window.location.href);
+        const session = toSession(result?.session ?? result);
+        persistSession(session);
+        const returnTo = window.sessionStorage.getItem(RETURN_TO_STORAGE_KEY);
+        window.sessionStorage.removeItem(RETURN_TO_STORAGE_KEY);
+        window.history.replaceState({}, document.title, window.location.pathname);
+        if (returnTo && returnTo !== window.location.pathname) {
+          window.location.replace(returnTo);
+        }
+        return session;
       }
-      return session;
+
+      const restored = toSession(await client.restore?.());
+      if (restored) {
+        persistSession(restored);
+        return restored;
+      }
+
+      const localSession = window.localStorage.getItem(SESSION_STORAGE_KEY);
+      return localSession ? toSession(JSON.parse(localSession)) : null;
+    } catch (error) {
+      console.error(error);
+      return null;
+    } finally {
+      restorePromise = null;
     }
-    const restored = toSession(await client.restore?.());
-    if (restored) {
-      persistSession(restored);
-      return restored;
-    }
-    const localSession = window.localStorage.getItem(SESSION_STORAGE_KEY);
-    return localSession ? toSession(JSON.parse(localSession)) : null;
-  } catch (error) {
-    console.error(error);
-    return null;
-  }
+  })();
+
+  return restorePromise;
 }
 
 export async function beginOAuthSignIn(handle: string) {


### PR DESCRIPTION
### Motivation

- Prevent concurrent `restoreOAuthSession()` callers from double-processing OAuth callback params and clobbering a valid session. 
- Eliminate a timing/race condition observed when both layout bootstrap and the comments component call the restore flow during the OAuth redirect.

### Description

- Added a module-level single-flight `restorePromise` to `src/lib/atreply-oauth.ts` so multiple calls reuse the same in-flight restore operation.
- Reworked `restoreOAuthSession()` to return the shared promise, run the callback/restore/localStorage flow once, and clear `restorePromise` in a `finally` block so future restores still operate normally.
- Preserved existing behaviors: callback handling persists session, clears URL params, honors `returnTo`, falls back to `client.restore()` and localStorage when appropriate.

### Testing

- No automated tests were run for this change (per requester instruction).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f571e13ad08332b7debf761f85b7f9)

## Summary by Sourcery

通过将所有对 `restoreOAuthSession` 的调用统一路由到一个共享的进行中（in-flight）Promise，防止并发的 OAuth 会话恢复调用发生冲突。

Bug Fixes:
- 确保多个并发的 `restoreOAuthSession` 调用共享同一个进行中的恢复逻辑，避免对 OAuth 回调进行重复处理并破坏（clobber）当前会话。

Enhancements:
- 将 OAuth 会话恢复流程集中到一个可复用的、基于 Promise 的路径中，同时仍然保留现有的回调处理逻辑、会话持久化机制以及返回路径（return-to）行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent concurrent OAuth session restoration calls from conflicting by routing all restoreOAuthSession invocations through a single shared in-flight promise.

Bug Fixes:
- Ensure multiple concurrent restoreOAuthSession calls share the same in-flight restore logic to avoid double-processing OAuth callbacks and clobbering the session.

Enhancements:
- Centralize OAuth session restoration flow into a reusable promise-based pathway that still preserves existing callback handling, session persistence, and return-to behavior.

</details>