### PR TITLE
Fix atproto comment session restore after OAuth

### DIFF
--- a/src/lib/atreply-oauth.ts
+++ b/src/lib/atreply-oauth.ts
@@ -11,11 +11,30 @@ let restorePromise: Promise<AtReplySession | null> | null = null;
 
 function toSession(raw: any): AtReplySession | null {
   if (!raw) return null;
+
+  const source = raw.session ?? raw;
+  const did = source.did ?? source.sub;
+  const handle = source.handle ?? source.username;
+  const accessToken =
+    source.accessJwt ??
+    source.accessToken ??
+    source.tokenSet?.access ??
+    source.tokenSet?.access_token ??
+    source.tokens?.accessJwt ??
+    source.tokens?.accessToken;
+  const pdsUrl =
+    source.pdsUrl ??
+    source.aud ??
+    source.dpopBoundAccessTokens?.resourceServer ??
+    'https://bsky.social';
+
+  if (!did || !accessToken) return null;
+
   return {
-    did: raw.did,
-    handle: raw.handle,
-    accessToken: raw.accessJwt ?? raw.accessToken,
-    pdsUrl: raw.pdsUrl ?? raw.aud ?? 'https://bsky.social',
+    did,
+    handle,
+    accessToken,
+    pdsUrl,
   };
 }
 
@@ -71,7 +90,9 @@ export function restoreOAuthSession() {
       }
 
       const localSession = window.localStorage.getItem(SESSION_STORAGE_KEY);
-      return localSession ? toSession(JSON.parse(localSession)) : null;
+      const recovered = localSession ? toSession(JSON.parse(localSession)) : null;
+      if (recovered) persistSession(recovered);
+      return recovered;
     } catch (error) {
       console.error(error);
       return null;


### PR DESCRIPTION
### Motivation
- The comments UI could remain disabled after a successful atproto OAuth flow because the restored payload shape wasn't always parsed into a usable session.
- Local `localStorage`-only restores did not re-dispatch the session event, so components listening for `ATREPLY_SESSION_EVENT` would not enable posting state after a reload.

### Description
- Normalize OAuth responses in `toSession` to accept multiple shapes (wrapping `session`, `tokenSet`, `tokens`, `sub`/`username`, etc.) and derive `did`, `handle`, `accessToken`, and `pdsUrl` consistently.
- Require both `did` and `accessToken` before treating a payload as a valid session to avoid false-positive sessions.
- When falling back to `localStorage`, convert and re-persist the recovered session via `persistSession` so `ATREPLY_SESSION_EVENT` is dispatched and listeners are notified.
- Modified file: `src/lib/atreply-oauth.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f57328dca4833289d6898726b8408f)

## Summary by Sourcery

提高恢复 atproto OAuth 评论会话的可靠性，并确保在会话恢复时正确通知监听器。

Bug 修复：
- 将不同形式的 OAuth 响应负载统一规范为一致的会话模型，防止恢复出无效或不可用的会话。
- 在将负载视为有效会话之前，必须同时具备 DID 和访问令牌，以避免误判为已登录状态。
- 从 localStorage 恢复时重新分发会话持久化流程，使 ATREPLY 会话监听器在刷新后能够正确启用评论功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve reliability of restoring atproto OAuth comment sessions and ensure listeners are notified on session recovery.

Bug Fixes:
- Normalize varied OAuth response payload shapes into a consistent session model to prevent invalid or unusable restored sessions.
- Require both a DID and access token before treating a payload as a valid session to avoid false-positive logged-in states.
- Re-dispatch the session persistence flow when restoring from localStorage so ATREPLY session listeners correctly enable commenting after reloads.

</details>