### PR TITLE
Disable DPoP-bound access tokens in OAuth client metadata

### DIFF
--- a/src/app/client-metadata.json/route.ts
+++ b/src/app/client-metadata.json/route.ts
@@ -19,6 +19,6 @@ export function GET(request: Request) {
     scope: 'atproto transition:generic',
     redirect_uris: [redirectUrl],
     token_endpoint_auth_method: 'none',
-    dpop_bound_access_tokens: true,
+    dpop_bound_access_tokens: false,
   });
 }


### PR DESCRIPTION
### Motivation
- The frontend comment publisher sends a standard Bearer token to `com.atproto.repo.createRecord`, so issuing DPoP-bound access tokens caused post-auth comment submissions to fail because the client does not attach DPoP proofs.

### Description
- Changed `dpop_bound_access_tokens` from `true` to `false` in `src/app/client-metadata.json/route.ts` so the OAuth flow issues non-DPoP (Bearer) tokens compatible with the current comment publish implementation.

### Testing
- No automated tests were run for this trivial metadata change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f574400c8c8332857ccee3c33b45fb)

## Summary by Sourcery

改进内容：
- 在 OAuth 客户端元数据中禁用基于 DPoP 绑定的访问令牌，以便已签发的令牌与不发送 DPoP 证明的客户端兼容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Disable DPoP-bound access tokens in the OAuth client metadata so issued tokens are compatible with clients that do not send DPoP proofs.

</details>